### PR TITLE
Move parent POM to project root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ jdk:
   - oraclejdk8
 
 script:
-  mvn -f idp-oidc-extension-parent/pom.xml clean package
+  mvn clean package

--- a/README.md
+++ b/README.md
@@ -17,13 +17,10 @@ The Shibboleth IdP 3.4 installed by this project is extended to act as a [OpenID
 The maven project needs to be built first. The ansible scipts will then perform first installation of Shibboleth Idp V3, after which the extensions are installed. 
 
 ```
-
 git clone https://github.com/CSCfi/shibboleth-idp-oidc-extension
-cd shibboleth-idp-oidc-extension/idp-oidc-extension-parent/
+cd shibboleth-idp-oidc-extension/
 mvn package
-cd ..
 vagrant up
-
 ```
 
 ## Playing around

--- a/idp-oidc-extension-api/pom.xml
+++ b/idp-oidc-extension-api/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>idp-oidc-extension-parent</artifactId>
         <groupId>org.geant</groupId>
         <version>0.8.0</version>
-        <relativePath>../idp-oidc-extension-parent</relativePath>
     </parent>
     <artifactId>idp-oidc-extension-api</artifactId>
     <packaging>jar</packaging>

--- a/idp-oidc-extension-distribution/pom.xml
+++ b/idp-oidc-extension-distribution/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>idp-oidc-extension-parent</artifactId>
         <groupId>org.geant</groupId>
         <version>0.8.0</version>
-        <relativePath>../idp-oidc-extension-parent</relativePath>
     </parent>
     <artifactId>idp-oidc-extension-distribution</artifactId>
     <build>

--- a/idp-oidc-extension-impl/pom.xml
+++ b/idp-oidc-extension-impl/pom.xml
@@ -9,7 +9,6 @@
         <artifactId>idp-oidc-extension-parent</artifactId>
         <groupId>org.geant</groupId>
         <version>0.8.0</version>
-        <relativePath>../idp-oidc-extension-parent</relativePath>
     </parent>
     <artifactId>idp-oidc-extension-impl</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <opensaml.version>3.4.0</opensaml.version>
         <checkstyle.version>2.17</checkstyle.version>
         <checkstyle.configLocation>
-            ../conf/checkstyle.xml
+            conf/checkstyle.xml
         </checkstyle.configLocation>
     </properties>
     <repositories>
@@ -49,9 +49,9 @@
         </repository>
     </repositories>
     <modules>
-        <module>../idp-oidc-extension-api</module>
-        <module>../idp-oidc-extension-impl</module>
-        <module>../idp-oidc-extension-distribution</module>
+        <module>idp-oidc-extension-api</module>
+        <module>idp-oidc-extension-impl</module>
+        <module>idp-oidc-extension-distribution</module>
     </modules>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
Move `idp-oidc-extension-parent/pom.xml` to the project's root
directory. This simplifies the Maven build configuration.

Fixes CSCfi/shibboleth-idp-oidc-extension#2