### PR TITLE
Add target and allow overriding extra jars

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,26 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             ansible.extra_vars = {
 #              service_name: "gn43-oidcshibop-devel.local",
               service_name: "192.168.0.150",
-              host_name: "gn43-oidcshibop-devel"
+              host_name: "gn43-oidcshibop-devel",
+              # Allow override copying extra jars completely by defining empty arrays
+              jetty_jars: [
+              ],
+              # Allow overriding location of jars
+              shibbolethidp_jars: [
+                { name: "mariadb-java-client",
+                  url: "http://central.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/1.5.9/mariadb-java-client-1.5.9.jar",
+                  dst: "/opt/shibboleth-idp/edit-webapp/WEB-INF/lib/"
+                },
+                { name: "commons-dbcp2",
+                  url: "http://central.maven.org/maven2/org/apache/commons/commons-dbcp2/2.1.1/commons-dbcp2-2.1.1.jar",
+                  dst: "/opt/shibboleth-idp/edit-webapp/WEB-INF/lib/"
+                },
+                {
+                  name: "commons-pool2",
+                  url: "http://central.maven.org/maven2/org/apache/commons/commons-pool2/2.4.2/commons-pool2-2.4.2.jar",
+                  dst: "/opt/shibboleth-idp/edit-webapp/WEB-INF/lib/"
+                }
+              ]
             }
         end
         app.vm.provision :shell, inline: "sudo /sbin/ifdown eth1 && sudo /sbin/ifup eth1"

--- a/idp-oidc-extension-distribution/src/main/resources/conf/oidc-relying-party.xml
+++ b/idp-oidc-extension-distribution/src/main/resources/conf/oidc-relying-party.xml
@@ -93,7 +93,8 @@
     <bean id="shibboleth.oidc.EncryptionConfiguration" parent="shibboleth.BasicEncryptionConfiguration">
         <property name="keyTransportEncryptionAlgorithms">
             <list>
-                <util:constant static-field="org.geant.idpextension.oidc.crypto.support.KeyTransportConstants.ALGO_ID_KEYTRANSPORT_ALG_RSA_1_5" />
+              <util:constant static-field="org.geant.idpextension.oidc.crypto.support.KeyTransportConstants.ALGO_ID_KEYTRANSPORT_ALG_RSA_1_5" />
+	      <util:constant static-field="org.geant.idpextension.oidc.crypto.support.KeyTransportConstants.ALGO_ID_KEYTRANSPORT_ALG_RSA_OAEP" />
             </list>
          </property>
         <property name="dataEncryptionAlgorithms">

--- a/oidcshibop.yml
+++ b/oidcshibop.yml
@@ -9,7 +9,7 @@
     - { role: CSCfi.389-ds, dirsrv_password: testpword, replpwd: testpword, administration_domain: csc.fi, root: "dc=csc,dc=fi", supplier: "{{ service_name }}", mode: single, service_name: "{{ service_name }}", aci: "teppo@{{ service_name }}"}
     - { role: CSCfi.mariadb, mariadb_root_password: testpass }
     - { role: CSCfi.jetty }
-    - { role: CSCfi.shibboleth-idp, shibbolethidp_version: 3.4.0,  configurables: ['consent','nameid'], scope: csc.fi, port: 8443, bport: 8444, keystore_password: testpword }
+    - { role: shibboleth-idp, shibbolethidp_version: 3.4.0,  configurables: ['consent','nameid'], scope: csc.fi, port: 8443, bport: 8444, keystore_password: testpword }
     - { role: keystore, idp: true, keystore_password: testpword }
     - { role: testenvironment, idp_home: /opt/shibboleth-idp, dirsrv_rootdn: "cn=Directory Manager", dirsrv_password: testpword, replpwd: testpword, administration_domain: csc.fi, root: "dc=csc,dc=fi", supplier: "{{ service_name }}", mode: single, service_name: "{{ service_name }}", aci: "teppo@{{ service_name }}"}
     - { role: oidc-extension, build_user: vagrant, idp_home: /opt/shibboleth-idp, service_name: "{{ service_name }}"}

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,6 +2,7 @@
 - src: cmprescott.xml
 - src: CSCfi.mariadb
 - src: CSCfi.jetty
-- src: CSCfi.shibboleth-idp
+- src: https://github.com/klaalo/ansible-role-shibboleth-idp
+  name: shibboleth-idp
 - src: CSCfi.apache
 - src: CSCfi.389-ds

--- a/roles/oidc-extension/tasks/main.yml
+++ b/roles/oidc-extension/tasks/main.yml
@@ -11,7 +11,7 @@
     - "../../../idp-oidc-extension-distribution/target/idp-oidc-extension-distribution*.tar.gz"
 
 - name: Build new idp.war
-  shell: source {{ environment_file }} && "{{ idp_home }}/bin/build.sh"
+  shell: "source {{ environment_file }} && {{ idp_home }}/bin/build.sh -Didp.target.dir={{ idp_home }}"
   become_user: root
 
 - name: Add global-oidc.xml import to global.xml


### PR DESCRIPTION
Example to override extra jars migth be useful for some. Adding `idp.target.dir` ensures build script doesn't hang waiting user input.