### PR TITLE
Removed erroneous bean close tag

### DIFF
--- a/idp-oidc-extension-distribution/src/main/resources/conf/oidc-metadata-providers.xml
+++ b/idp-oidc-extension-distribution/src/main/resources/conf/oidc-metadata-providers.xml
@@ -49,7 +49,6 @@
         class="org.geant.idpextension.oidc.metadata.impl.FilesystemClientInformationResolver" 
         p:id="ExampleFileResolver1"
         p:remoteJwkSetCache-ref="shibboleth.oidc.RemoteJwkSetCache" c:metadata="/opt/shibboleth-idp/metadata/oidc-client.json" />
-    </bean>
 -->
 
     <bean id="ExampleStorageClientInformationResolver"


### PR DESCRIPTION
The close bean tag isn't necessary after the ExampleFileResolver example was condensed