### PR TITLE
Pin transitive dependencies of com.nimbusds:oauth2-oidc-sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,21 @@
                 <version>6.5</version>
             </dependency>
             <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>lang-tag</artifactId>
+                <version>1.4.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>8.8</version>
+            </dependency>
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>2.3</version>
+            </dependency>
+            <dependency>
                 <groupId>org.geant</groupId>
                 <version>${project.version}</version>
                 <artifactId>idp-oidc-extension-api</artifactId>


### PR DESCRIPTION
Artifact `com.nimbusds:oauth2-oidc-sdk:jar:6.5` uses version ranges
for some of its transitive dependencies. This leads to compilation
failures because newer versions which are no longer compatible with
release 1.1.1 are now being picked up. Manage the version of those
transitive dependencies so that they remain the same as what release
1.1.1 was built with.